### PR TITLE
all: load content from content.jquery.com with https

### DIFF
--- a/build_production/2009/11/13/announcing-the-official-jquery-podcast/index.html
+++ b/build_production/2009/11/13/announcing-the-official-jquery-podcast/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="1 - John Resig"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="John Resig joins us on our first podcast to talk jQuery, the Software Freedom Conservancy, the upcoming 1.4 release and why Google Groups is dead."/>
   <meta name="description" content="John Resig joins us on our first podcast to talk jQuery, the Software Freedom Conservancy, the upcoming 1.4 release and why Google Groups is dead."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2009/11/20/episode-2-richard-d-worth/index.html
+++ b/build_production/2009/11/20/episode-2-richard-d-worth/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="2 - Richard D. Worth"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Richard D. Worth, Release Manager for the jQuery UI project joins us to explain jQuery UI and how you can contribute."/>
   <meta name="description" content="Richard D. Worth, Release Manager for the jQuery UI project joins us to explain jQuery UI and how you can contribute."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3" controls=""></audio></p>
 
 <h2>Links from the show…</h2>
 

--- a/build_production/2009/12/04/episode-3-paul-irish/index.html
+++ b/build_production/2009/12/04/episode-3-paul-irish/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="3 - Paul Irish"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Paul Irish is a front-end developer and co-host of the other jQuery podcast called yayQuery."/>
   <meta name="description" content="Paul Irish is a front-end developer and co-host of the other jQuery podcast called yayQuery."/>
@@ -45,7 +45,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3" controls=""></audio></p>
 
 <h2>Links from the show</h2>
 

--- a/build_production/2009/12/11/episode-4-cody-lindley/index.html
+++ b/build_production/2009/12/11/episode-4-cody-lindley/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="4 - Cody Lindley"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Cody Lindley is the author of the e-book jQuery Enlightenment and the coauthor of jQuery Cookbook. Learn all about the recently released jQuery books."/>
   <meta name="description" content="Cody Lindley is the author of the e-book jQuery Enlightenment and the coauthor of jQuery Cookbook. Learn all about the recently released jQuery books."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3" controls=""></audio></p>
 
 <h2>This Week in jQuery</h2>
 

--- a/build_production/2010/01/01/episode-5-rey-bango/index.html
+++ b/build_production/2010/01/01/episode-5-rey-bango/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="5 - Rey Bango"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Rey Bango is the Head jQuery Evangelist, he talks with us about evangelism and what to expect in 2010."/>
   <meta name="description" content="Rey Bango is the Head jQuery Evangelist, he talks with us about evangelism and what to expect in 2010."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3" controls=""></audio></p>
 
 <h2>Links from the show</h2>
 

--- a/build_production/2010/01/10/episode-6-ben-alman/index.html
+++ b/build_production/2010/01/10/episode-6-ben-alman/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="6 - Ben Alman"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk with Ben Alman about writing plugins and contributing to jQuery.  Elijah joins us after getting braces on, much hilarity ensues."/>
   <meta name="description" content="We talk with Ben Alman about writing plugins and contributing to jQuery.  Elijah joins us after getting braces on, much hilarity ensues."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/01/15/episode-7-jquery-1-4-release-john-resig/index.html
+++ b/build_production/2010/01/15/episode-7-jquery-1-4-release-john-resig/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="7 - jQuery 1.4 (John Resig)"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We are in Washington DC and we are all sitting face-to-face with John Resig as we talk about the jQuery 1.4 Release."/>
   <meta name="description" content="We are in Washington DC and we are all sitting face-to-face with John Resig as we talk about the jQuery 1.4 Release."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/01/22/episode-8-api-jquery-com/index.html
+++ b/build_production/2010/01/22/episode-8-api-jquery-com/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="8 - api.jquery.com"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="The jQuery Documentation got a major facelift and was released during the 14 Days of jQuery. In this episode we are at the Aol headquarters in Washington DC filming video and releasing jQuery 1.4 for the 14 Days of jQuery. In this episode we talk with Karl Swedberg and Paul Irish about the new api.jquery.com documentation site."/>
   <meta name="description" content="The jQuery Documentation got a major facelift and was released during the 14 Days of jQuery. In this episode we are at the Aol headquarters in Washington DC filming video and releasing jQuery 1.4 for the 14 Days of jQuery. In this episode we talk with Karl Swedberg and Paul Irish about the new api.jquery.com documentation site."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/01/29/episode-9-david-artz-aol/index.html
+++ b/build_production/2010/01/29/episode-9-david-artz-aol/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="9 - David Artz, Aol."/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We took the opportunity to sit down with David Artz and discuss how jQuery is used at Aol."/>
   <meta name="description" content="We took the opportunity to sit down with David Artz and discuss how jQuery is used at Aol."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/02/14/episode-10-appendto-llc/index.html
+++ b/build_production/2010/02/14/episode-10-appendto-llc/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="10 - appendTo"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We took the opportunity to sit down with Mike Hostetler and Jonathon Sharp to discuss appendTo.  The first jQuery company that provides support, training and consultation at the Enterprise level."/>
   <meta name="description" content="We took the opportunity to sit down with Mike Hostetler and Jonathon Sharp to discuss appendTo.  The first jQuery company that provides support, training and consultation at the Enterprise level."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/02/15/episode-11-yehuda-katz/index.html
+++ b/build_production/2010/02/15/episode-11-yehuda-katz/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="11 - Yehuda Katz"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Our last show while in Washington DC we sat down and talked with Yehuda Katz about Rails 3 and jQuery."/>
   <meta name="description" content="Our last show while in Washington DC we sat down and talked with Yehuda Katz about Rails 3 and jQuery."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/02/19/episode-12-rey-bomb-1/index.html
+++ b/build_production/2010/02/19/episode-12-rey-bomb-1/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="12 - Rey Bomb 1"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk about jQuery at a casual level and try to discuss some topics we normally wouldn&#039;t during an interview episode."/>
   <meta name="description" content="We talk about jQuery at a casual level and try to discuss some topics we normally wouldn&#039;t during an interview episode."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/02/26/episode-13-david-walsh/index.html
+++ b/build_production/2010/02/26/episode-13-david-walsh/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="13 - David Walsh"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk with Mootools developer David Walsh and discuss the relationship between our teams and compare the libraries."/>
   <meta name="description" content="We talk with Mootools developer David Walsh and discuss the relationship between our teams and compare the libraries."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/03/05/episode-14-phil-haack/index.html
+++ b/build_production/2010/03/05/episode-14-phil-haack/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="14 - Phil Haack"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk with Phil Haack of Microsoft to talk about how jQuery is now included in Visual Studio and ASP.NET MVC and how easy it is to use."/>
   <meta name="description" content="We talk with Phil Haack of Microsoft to talk about how jQuery is now included in Visual Studio and ASP.NET MVC and how easy it is to use."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/03/12/episode-15-john-resig-jquery-1-4-1-1-4-2/index.html
+++ b/build_production/2010/03/12/episode-15-john-resig-jquery-1-4-1-1-4-2/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="15 - John Resig (1.4.1 - 1.4.2)"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk with John Resig about jQuery 1.4.1 and jQuery 1.4.2 as well as what&#039;s ahead in jQuery 1.4.3 and beyond."/>
   <meta name="description" content="We talk with John Resig about jQuery 1.4.1 and jQuery 1.4.2 as well as what&#039;s ahead in jQuery 1.4.3 and beyond."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/03/19/episode-16-jquery-meetups/index.html
+++ b/build_production/2010/03/19/episode-16-jquery-meetups/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="16 - jQuery Meetups"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk with Cody Lindley, Jonathan Sharp and Boaz Sender about meetups.jquery.com and try to help come up with ideas and process for hosting jQuery Meetups in your area."/>
   <meta name="description" content="We talk with Cody Lindley, Jonathan Sharp and Boaz Sender about meetups.jquery.com and try to help come up with ideas and process for hosting jQuery Meetups in your area."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/03/26/episode-17-jquery-ui-1-8/index.html
+++ b/build_production/2010/03/26/episode-17-jquery-ui-1-8/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="17 - jQuery UI 1.8"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talked last week with the jQuery UI team right before the launch of jQuery UI 1.8, Richard D. Worth, Scott Gonzalez, Mike Hostetler and Doug Neiner filled in for Elijah.  We discuss the final release of jQuery UI 1.8."/>
   <meta name="description" content="We talked last week with the jQuery UI team right before the launch of jQuery UI 1.8, Richard D. Worth, Scott Gonzalez, Mike Hostetler and Doug Neiner filled in for Elijah.  We discuss the final release of jQuery UI 1.8."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/04/02/episode-18-jeffery-way-nettuts/index.html
+++ b/build_production/2010/04/02/episode-18-jeffery-way-nettuts/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="18 - Jeffery Way (Nettuts)"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we talked with Jeffrey Way. He is the editor of Nettuts+, and the Site Manager of ThemeForest and CodeCanyon. Jeffrey gives an overview of the Nettuts+ website and explains why their tutorials focus so much on jQuery and gives some examples of recent jQuery related articles."/>
   <meta name="description" content="This week we talked with Jeffrey Way. He is the editor of Nettuts+, and the Site Manager of ThemeForest and CodeCanyon. Jeffrey gives an overview of the Nettuts+ website and explains why their tutorials focus so much on jQuery and gives some examples of recent jQuery related articles."/>
@@ -43,7 +43,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/04/09/episode-19-jquery-in-action-2nd-ed/index.html
+++ b/build_production/2010/04/09/episode-19-jquery-in-action-2nd-ed/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="19 - jQuery in Action, 2nd Ed."/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we talked with Yehuda Katz and Bear Bibeault about the upcoming second edition of the popular jQuery in Action book from Manning."/>
   <meta name="description" content="This week we talked with Yehuda Katz and Bear Bibeault about the upcoming second edition of the popular jQuery in Action book from Manning."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Elijah Manor.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/04/16/episode-20-barcamp-rochester/index.html
+++ b/build_production/2010/04/16/episode-20-barcamp-rochester/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="20 - Barcamp Rochester"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we provide you with three short interviews recorded at Barcamp Rochester earlier this month.  John Resig gives us an update on the state of jQuery.  Benjamin DeLillo tells us about a new WebGL library called WebGLU and Mich Cook of Yahoo introduces us to YUI3."/>
   <meta name="description" content="This week we provide you with three short interviews recorded at Barcamp Rochester earlier this month.  John Resig gives us an update on the state of jQuery.  Benjamin DeLillo tells us about a new WebGL library called WebGLU and Mich Cook of Yahoo introduces us to YUI3."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3" controls=""></audio></p>
 
 <h2>Interviews</h2>
 

--- a/build_production/2010/04/24/episode-21-rey-bomb-2/index.html
+++ b/build_production/2010/04/24/episode-21-rey-bomb-2/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="21 - Rey Bomb 2"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we discuss JSConf, Rey&#039;s new position at Microsoft, Microsoft/jQuery relationship and jQuery Conference.  This is also the last show for Elijah and he is stepping down to spend more time with family."/>
   <meta name="description" content="This week we discuss JSConf, Rey&#039;s new position at Microsoft, Microsoft/jQuery relationship and jQuery Conference.  This is also the last show for Elijah and he is stepping down to spend more time with family."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/05/07/episode-22-james-senior/index.html
+++ b/build_production/2010/05/07/episode-22-james-senior/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="22 - James Senior"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we sat down with James Senior a Web Technology evangelist at Microsoft and discussed jQuery/Microsoft.  We also announce Rey Bango as the new co-host of the show."/>
   <meta name="description" content="This week we sat down with James Senior a Web Technology evangelist at Microsoft and discussed jQuery/Microsoft.  We also announce Rey Bango as the new co-host of the show."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/05/18/episode-23-nicholas-zakas/index.html
+++ b/build_production/2010/05/18/episode-23-nicholas-zakas/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="23 - Nicholas Zakas"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we sat down with Nicholas Zakas to talk about High Performance JavaScript."/>
   <meta name="description" content="This week we sat down with Nicholas Zakas to talk about High Performance JavaScript."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/05/28/episode-24-yayquery/index.html
+++ b/build_production/2010/05/28/episode-24-yayquery/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="24 - yayQuery"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we sat down with the yayQuery hosts and discuss a bunch of topics."/>
   <meta name="description" content="This week we sat down with the yayQuery hosts and discuss a bunch of topics."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/06/04/episode-25-menno-van-slooten/index.html
+++ b/build_production/2010/06/04/episode-25-menno-van-slooten/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="25 - Meeno Van Slooten"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we sat down with Meeno Van Slooten who was a speaker at the Bay Area jQuery Conference 2010 and showed off a cool new UI Testing Framework he developed."/>
   <meta name="description" content="This week we sat down with Meeno Van Slooten who was a speaker at the Bay Area jQuery Conference 2010 and showed off a cool new UI Testing Framework he developed."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/06/11/episode-26-remy-sharp-part-1/index.html
+++ b/build_production/2010/06/11/episode-26-remy-sharp-part-1/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="26 - Remy Sharp pt. 1 (jsbin.com)"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we sat down and talked with Remy Sharp and discussed jsbin.com a site to try out and share HTML and JavaScript quickly and easily."/>
   <meta name="description" content="This week we sat down and talked with Remy Sharp and discussed jsbin.com a site to try out and share HTML and JavaScript quickly and easily."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/06/18/episode-27-remy-sharp-part-2/index.html
+++ b/build_production/2010/06/18/episode-27-remy-sharp-part-2/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="27 - Remy Sharp pt. 2 (HTML5)"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we sat down and talked with Remy Sharp and discussed HTML5."/>
   <meta name="description" content="This week we sat down and talked with Remy Sharp and discussed HTML5."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/06/25/episode-28-remy-sharp-part-3-jquery-for-designers/index.html
+++ b/build_production/2010/06/25/episode-28-remy-sharp-part-3-jquery-for-designers/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="28 - Remy Sharp pt. 3 (jQuery for Designers)"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="This week we sat down and talked with Remy Sharp and discussed jQuery for Designers, Full Frontal JavaScript Conference, Snap Bird and have a little fun."/>
   <meta name="description" content="This week we sat down and talked with Remy Sharp and discussed jQuery for Designers, Full Frontal JavaScript Conference, Snap Bird and have a little fun."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/07/09/episode-29-rey-bomb-3/index.html
+++ b/build_production/2010/07/09/episode-29-rey-bomb-3/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="29 - Rey Bomb 3"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk about a new front-end focused tutorial site, Script Junkies and we talk about the mobile strategy of jQuery."/>
   <meta name="description" content="We talk about a new front-end focused tutorial site, Script Junkies and we talk about the mobile strategy of jQuery."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/07/30/episode-30-chris-coyier/index.html
+++ b/build_production/2010/07/30/episode-30-chris-coyier/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="30 - Chris Coyier"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk to Chris Coyier about jQuery, css-tricks.com and Wufoo ."/>
   <meta name="description" content="We talk to Chris Coyier about jQuery, css-tricks.com and Wufoo ."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/08/19/episode-31-filament-group/index.html
+++ b/build_production/2010/08/19/episode-31-filament-group/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="31 - Filament Group"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk to the folks at Filament Group about Progressive Enhancement, jQuery UI and Mobile.."/>
   <meta name="description" content="We talk to the folks at Filament Group about Progressive Enhancement, jQuery UI and Mobile.."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/08/27/episode-32-dave-ward/index.html
+++ b/build_production/2010/08/27/episode-32-dave-ward/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="32 - Dave Ward"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Talk with Dave Ward about the Master jQuery series on Tekpub and caching on Google CDN, etc."/>
   <meta name="description" content="Talk with Dave Ward about the Master jQuery series on Tekpub and caching on Google CDN, etc."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/09/10/karl-swedberg-part-1/index.html
+++ b/build_production/2010/09/10/karl-swedberg-part-1/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="33 - Karl Swedberg pt. 1"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Karl Swedberg joins us this week to chat about the community needs of jQuery and what we know now nine months after api.jquery.com has launched."/>
   <meta name="description" content="Karl Swedberg joins us this week to chat about the community needs of jQuery and what we know now nine months after api.jquery.com has launched."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/09/17/episode-34-karl-swedberg-part-2/index.html
+++ b/build_production/2010/09/17/episode-34-karl-swedberg-part-2/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="34 - Karl Swedberg pt. 2"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Karl Swedberg joins us again this week to chat about Learning jQuery and the upcoming jQuery conference."/>
   <meta name="description" content="Karl Swedberg joins us again this week to chat about Learning jQuery and the upcoming jQuery conference."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/09/30/episode-35-jquery-ui-1-8-5/index.html
+++ b/build_production/2010/09/30/episode-35-jquery-ui-1-8-5/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="35 - jQuery UI 1.8.5"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Scott González, Lead Developer for jQuery UI joins us to talk about the latest release of jQuery UI and the road ahead."/>
   <meta name="description" content="Scott González, Lead Developer for jQuery UI joins us to talk about the latest release of jQuery UI and the road ahead."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/10/06/episode-36-bocoup/index.html
+++ b/build_production/2010/10/06/episode-36-bocoup/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="36 - Bocoup"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We sit down with Boaz Sender and Ben Alman who both work for Bocoup in Boston, MA.  We discuss Bocoup from their clients to their open source contributions.  Bocoup is providing the pre-conference training in Boston and we talk about the training class and the advance classes that are also offered.  Bocoup Loft also hosts many events including jQuery Meetups in Boston."/>
   <meta name="description" content="We sit down with Boaz Sender and Ben Alman who both work for Bocoup in Boston, MA.  We discuss Bocoup from their clients to their open source contributions.  Bocoup is providing the pre-conference training in Boston and we talk about the training class and the advance classes that are also offered.  Bocoup Loft also hosts many events including jQuery Meetups in Boston."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2010/10/22/episode-37-ben-nadel/index.html
+++ b/build_production/2010/10/22/episode-37-ben-nadel/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="37 - Ben Nadel"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Fresh off the jQuery Conference 2010: Boston, we sit down with Ben Nadel and talk about the conference.  Ben tells us about what he learned and tells us about the awesome photo he got with the jQuery Community.  Ben’s a jQuery spokesperson for the Cold Fusion community and we talk about that as well."/>
   <meta name="description" content="Fresh off the jQuery Conference 2010: Boston, we sit down with Ben Nadel and talk about the conference.  Ben tells us about what he learned and tells us about the awesome photo he got with the jQuery Community.  Ben’s a jQuery spokesperson for the Cold Fusion community and we talk about that as well."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" controls=""></audio></p>
 
 <h2>Links from the show</h2>
 

--- a/build_production/2010/10/29/episode-38-jquery-1-4-3/index.html
+++ b/build_production/2010/10/29/episode-38-jquery-1-4-3/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="38 - jQuery 1.4.3"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="John Resig joins us to talk about the latest jQuery release, 1.4.3."/>
   <meta name="description" content="John Resig joins us to talk about the latest jQuery release, 1.4.3."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" controls=""></audio></p>
 
 <p>John Resig joins us this week to talk about the lastest jQuery release, 1.4.3. We go over some of the performance improvements, the CSS method rewrite, new data method additions amongst others. Find out everything you need to know about this release right here. Also find out details about how to get started testing the 1.4.4 RC.</p>
 

--- a/build_production/2010/11/10/episode-39-jquery-mobile/index.html
+++ b/build_production/2010/11/10/episode-39-jquery-mobile/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="39 - jQuery Mobile"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="John Resig joins us to talk about jQuery Mobile."/>
   <meta name="description" content="John Resig joins us to talk about jQuery Mobile."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" controls=""></audio></p>
 
 <h2>Description</h2>
 

--- a/build_production/2010/12/17/episode-40-wijmo/index.html
+++ b/build_production/2010/12/17/episode-40-wijmo/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="40 - Wijmo"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Chris Bannon from ComponentOne talks about Wijmo a new UI Library based on jQuery UI."/>
   <meta name="description" content="Chris Bannon from ComponentOne talks about Wijmo a new UI Library based on jQuery UI."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2011/04/22/episode-41-jquery-keynote/index.html
+++ b/build_production/2011/04/22/episode-41-jquery-keynote/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="41 - jQuery Keynote"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="John Resig delivers the jQuery Keynote from the jQuery Conference 2011: SF Bay Area. Follow along with the slides."/>
   <meta name="description" content="John Resig delivers the jQuery Keynote from the jQuery Conference 2011: SF Bay Area. Follow along with the slides."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" controls=""></audio></p>
 
 <h2>Description</h2>
 

--- a/build_production/2011/04/29/episode-42-jquery-mobile-keynote/index.html
+++ b/build_production/2011/04/29/episode-42-jquery-mobile-keynote/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="42 - jQuery Mobile Keynote"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Todd Parker and Scott Jehl deliver the jQuery Mobile keynote from the jQuery Conference 2011: SF BAy Area. Follow along with the slides."/>
   <meta name="description" content="Todd Parker and Scott Jehl deliver the jQuery Mobile keynote from the jQuery Conference 2011: SF BAy Area. Follow along with the slides."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" controls=""></audio></p>
 
 <h2>Description</h2>
 

--- a/build_production/2011/05/11/rewardjs/index.html
+++ b/build_production/2011/05/11/rewardjs/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="43 - RewardJS"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Talk with Richard D. Worth about his personal project RewardJS to reward developers to fix bugs."/>
   <meta name="description" content="Talk with Richard D. Worth about his personal project RewardJS to reward developers to fix bugs."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" controls=""></audio></p>
 
 <h2>Interview</h2>
 

--- a/build_production/2011/05/13/jquery-1-5-1-6-1/index.html
+++ b/build_production/2011/05/13/jquery-1-5-1-6-1/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="44 - jQuery 1.5 - 1.6.1"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="We talk with jQuery Core Team Member Dave Methvin about the last few releases."/>
   <meta name="description" content="We talk with jQuery Core Team Member Dave Methvin about the last few releases."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" controls=""></audio></p>
 
 <h2>Description</h2>
 

--- a/build_production/2011/05/20/jqcon-11-sf-bay-area-jquery-ui-keynote/index.html
+++ b/build_production/2011/05/20/jqcon-11-sf-bay-area-jquery-ui-keynote/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="45 - jQuery UI Keynote"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="Richard D. Worth presents the state of jQuery UI and a preview of the jQuery UI Grid project from the jQuery Conference 2011: San Francisco Bay Area."/>
   <meta name="description" content="Richard D. Worth presents the state of jQuery UI and a preview of the jQuery UI Grid project from the jQuery Conference 2011: San Francisco Bay Area."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" controls=""></audio></p>
 
 <h2>Description</h2>
 

--- a/build_production/2011/06/07/jqcon-11-sf-bay-area-panel-q-a/index.html
+++ b/build_production/2011/06/07/jqcon-11-sf-bay-area-panel-q-a/index.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="46 - Q&amp;A Panel from jQCon"/>
   <meta property="og:site_name" content="The Official jQuery Podcast"/>
   <meta property="og:image" content="https://cdn.jquery.net/podcast/wp-content/uploads/2010/09/jquerypodcast.png"/>
-  <meta property="og:audio" content="http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3"/>
+  <meta property="og:audio" content="https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3"/>
   <meta property="og:audio:type" content="audio/mpeg"/>
   <meta property="og:description" content="John Resig, Richard Worth, Adam Sontag, Dan Heberden, Leah Silber and Scott Jehl answers questions from the audience at jQuery Conference 2011 in San Francisco."/>
   <meta name="description" content="John Resig, Richard Worth, Adam Sontag, Dan Heberden, Leah Silber and Scott Jehl answers questions from the audience at jQuery Conference 2011 in San Francisco."/>
@@ -41,7 +41,7 @@
 
 <p>Host: Ralph Whitbeck &amp; Rey Bango.</p>
 
-<p><audio src="http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" controls=""></audio></p>
+<p><audio src="https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" controls=""></audio></p>
 
 <h2>Description</h2>
 

--- a/build_production/feed/jQueryPodcast.xml
+++ b/build_production/feed/jQueryPodcast.xml
@@ -24,8 +24,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>John Resig, Richard Worth, Adam Sontag, Dan Heberden, Leah Silber and Scott Jehl answers questions from the audience at jQuery Conference 2011 in San Francisco.</itunes:subtitle>
 			<itunes:summary>John Resig, Richard Worth, Adam Sontag, Dan Heberden, Leah Silber and Scott Jehl answers questions from the audience at jQuery Conference 2011 in San Francisco.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" length="27949980" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" length="27949980" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3</guid>
 			<pubDate>Tue, 7 Jun 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:58:04</itunes:duration>
 			<itunes:keywords>jquery, jquery ui</itunes:keywords>
@@ -35,8 +35,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Richard D. Worth presents the state of jQuery UI and a preview of the jQuery UI Grid project from the jQuery Conference 2011: San Francisco Bay Area.</itunes:subtitle>
 			<itunes:summary>Richard D. Worth presents the state of jQuery UI and a preview of the jQuery UI Grid project from the jQuery Conference 2011: San Francisco Bay Area.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" length="28509413" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" length="28509413" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3</guid>
 			<pubDate>Fri, 20 May 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:59:14</itunes:duration>
 			<itunes:keywords>jquery, jquery ui</itunes:keywords>
@@ -46,8 +46,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>We talk with jQuery Core Team Member Dave Methvin about the last few releases.</itunes:subtitle>
 			<itunes:summary>We talk with jQuery Core Team Member Dave Methvin about the last few releases.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" length="26581160" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" length="26581160" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3</guid>
 			<pubDate>Fri, 13 May 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:55:13</itunes:duration>
 			<itunes:keywords>jquery</itunes:keywords>
@@ -57,8 +57,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Talk with Richard D. Worth about his personal project RewardJS to reward developers to fix bugs.</itunes:subtitle>
 			<itunes:summary>Talk with Richard D. Worth about his personal project RewardJS to reward developers to fix bugs.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" length="17975180" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" length="17975180" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3</guid>
 			<pubDate>Tue, 10 May 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:37:17</itunes:duration>
 			<itunes:keywords>rewardjs, jquery ui</itunes:keywords>
@@ -68,8 +68,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Todd Parker and Scott Jehl deliver the jQuery Mobile keynote from the jQuery Conference 2011: SF BAy Area. Follow along with the slides at http://filamentgroup.com/lab/slides_from_our_jquery_conference_presentation_on_jquery_mobile/</itunes:subtitle>
 			<itunes:summary>Todd Parker and Scott Jehl deliver the jQuery Mobile keynote from the jQuery Conference 2011: SF BAy Area. Follow along with the slides at http://filamentgroup.com/lab/slides_from_our_jquery_conference_presentation_on_jquery_mobile/</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" length="33597455" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" length="33597455" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3</guid>
 			<pubDate>Fri, 29 Apr 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>01:09:50</itunes:duration>
 			<itunes:keywords>jquery, jquery mobile, javascript</itunes:keywords>
@@ -79,8 +79,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>John Resig delivers the jQuery Keynote from the jQuery Conference 2011: SF Bay Area</itunes:subtitle>
 			<itunes:summary>John Resig delivers the jQuery Keynote from the jQuery Conference 2011: SF Bay Area. Follow along with John's slides at http://www.slideshare.net/jeresig/jquery-keynote-spring-2011</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" length="18742768" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-041-jQCon1SFjQueryKeynote.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" length="18742768" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-041-jQCon1SFjQueryKeynote.mp3</guid>
 			<pubDate>Fri, 22 Apr 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:38:53</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -90,8 +90,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Chris Bannon from ComponentOne talks about Wijmo a new UI Library based on jQuery UI.</itunes:subtitle>
 			<itunes:summary>Chris Bannon from ComponentOne talks about Wijmo a new UI Library based on jQuery UI.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" length="16034175" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" length="16034175" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3</guid>
 			<pubDate>Thu, 16 Dec 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:33:15</itunes:duration>
 			<itunes:keywords>jquery, javascript, wijmo</itunes:keywords>
@@ -101,8 +101,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>John Resig joins us to talk about jQuery Mobile.</itunes:subtitle>
 				<itunes:summary>John Resig joins us to talk about jQuery Mobile.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" length="12344425" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" length="12344425" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3</guid>
 				<pubDate>Tue, 9 Nov 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:25:33</itunes:duration>
 				<itunes:keywords>jquery, javascript, mobile</itunes:keywords>
@@ -112,8 +112,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>John Resig joins us to talk about the latest jQuery release, 1.4.3.</itunes:subtitle>
 				<itunes:summary>John Resig joins us to talk about the latest jQuery release, 1.4.3.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" length="14397440" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" length="14397440" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3</guid>
 				<pubDate>Fri, 29 Oct 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:29:50</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -123,8 +123,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>We sit down with Ben Nadel and discuss Cold Fusion and the jQuery Conference this past weekend.</itunes:subtitle>
 				<itunes:summary>Fresh off the jQuery Conference 2010: Boston, we sit down with Ben Nadel and talk about the conference.  Ben tells us about what he learned and tells us about the awesome photo he got with the jQuery Community.  Ben’s a jQuery spokesperson for the Cold Fusion community and we talk about that as well.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" length="17577483" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" length="17577483" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3</guid>
 				<pubDate>Fri, 22 Oct 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:36:28</itunes:duration>
 				<itunes:keywords>jquery, javascript, jqcon</itunes:keywords>
@@ -134,8 +134,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>We sit down with Boaz Sender and Ben Alman who both work for Bocoup in Boston, MA.  We discuss Bocoup from their clients to their open source contributions.</itunes:subtitle>
 				<itunes:summary>We sit down with Boaz Sender and Ben Alman who both work for Bocoup in Boston, MA.  We discuss Bocoup from their clients to their open source contributions.  Bocoup is providing the pre-conference training in Boston and we talk about the training class and the advance classes that are also offered.  Bocoup Loft also hosts many events including jQuery Meetups in Boston.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3" length="20560458" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3" length="20560458" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3</guid>
 				<pubDate>Wed, 6 Oct 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:42:40</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -145,8 +145,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Scott González, Lead Developer for jQuery UI joins us to talk about the latest release of jQuery UI and the road ahead.</itunes:subtitle>
 				<itunes:summary>Scott González, Lead Developer for jQuery UI joins us to talk about the latest release of jQuery UI and the road ahead.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3" length="23197153" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3" length="23197153" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3</guid>
 				<pubDate>Thu, 30 Sep 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:48:10</itunes:duration>
 				<itunes:keywords>jquery, javascript, jQuery ui</itunes:keywords>
@@ -156,8 +156,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Karl Swedberg joins us again this week to chat about Learning jQuery and the upcoming jQuery conference.</itunes:subtitle>
 				<itunes:summary>Karl Swedberg joins us again this week to chat about Learning jQuery and the upcoming jQuery conference.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3" length="15985484" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3" length="15985484" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3</guid>
 				<pubDate>Fri, 17 Sep 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:33:09</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -167,8 +167,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Karl Swedberg joins us this week to chat about the community needs of jQuery and what we know now nine months after api.jquery.com has launched.</itunes:subtitle>
 				<itunes:summary>Karl Swedberg joins us this week to chat about the community needs of jQuery and what we know now nine months after api.jquery.com has launched.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3" length="17517715" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3" length="17517715" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3</guid>
 				<pubDate>Fri, 10 Sep 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:36:20</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -178,8 +178,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Dave Ward co host of the video series on Tekpub called Master jQuery</itunes:subtitle>
 				<itunes:summary>Talk with Dave Ward about the Master jQuery series on Tekpub and caching on Google CDN, etc.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3" length="20597656" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3" length="20597656" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3</guid>
 				<pubDate>Fri, 27 Aug 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:42:45</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -189,8 +189,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Filament Group, discussing Progressive Enhancement, jQuery UI and Mobile.</itunes:subtitle>
 				<itunes:summary>We talk to the folks at Filament Group about Progressive Enhancement, jQuery UI and Mobile..</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3" length="21193248" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3" length="21193248" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3</guid>
 				<pubDate>Fri, 13 Aug 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:44:00</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -200,8 +200,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Chris Coyier of css-tricks.com and Wufoo.</itunes:subtitle>
 				<itunes:summary>We talk to Chris Coyier about jQuery, css-tricks.com and Wufoo .</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3" length="27720517" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3" length="27720517" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3</guid>
 				<pubDate>Fri, 30 Jul 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:57:35</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -211,8 +211,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>The guys get together and discuss Script Junkie and Mobile jQuery.</itunes:subtitle>
 				<itunes:summary>We talk about a new front-end focused tutorial site, Script Junkies and we talk about the mobile strategy of jQuery.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3" length="22034182" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3" length="22034182" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3</guid>
 				<pubDate>Fri, 9 Jul 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:45:45</itunes:duration>
 				<itunes:keywords>jquery, javascript, mobile</itunes:keywords>
@@ -222,8 +222,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Remy Sharp, jQuery Developer Relations Team member and jsbin.com creator</itunes:subtitle>
 				<itunes:summary>This week we sat down and talked with Remy Sharp and discussed jQuery for Designers, Full Frontal JavaScript Conference, Snap Bird and have a little fun.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3" length="18372271" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3" length="18372271" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3</guid>
 				<pubDate>Fri, 25 Jun 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:38:07</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -233,8 +233,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Remy Sharp, jQuery Developer Relations Team member and jsbin.com creator</itunes:subtitle>
 				<itunes:summary>This week we sat down and talked with Remy Sharp and discussed HTML5.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3" length="14077493" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3" length="14077493" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3</guid>
 				<pubDate>Fri, 18 Jun 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:29:10</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -244,8 +244,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Remy Sharp, jQuery Developer Relations Team member and jsbin.com creator</itunes:subtitle>
 				<itunes:summary>This week we sat down and talked with Remy Sharp and discussed jsbin.com a site to try out and share HTML and JavaScript quickly and easily.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3" length="14539338" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3" length="14539338" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3</guid>
 				<pubDate>Fri, 11 Jun 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:30:08</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -255,8 +255,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Meeno Van Slooten was a speaker at the Bay Area jQuery Conference 2010 and showed off a cool new UI Testing Framework he developed.</itunes:subtitle>
 				<itunes:summary>This week we sat down with Meeno Van Slooten who was a speaker at the Bay Area jQuery Conference 2010 and showed off a cool new UI Testing Framework he developed.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3" length="11597741 " type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3" length="11597741 " type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3</guid>
 				<pubDate>Fri, 4 Jun 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:24:00</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -266,8 +266,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>The hosts of the yayQuery podcast talk with Rey and Ralph.</itunes:subtitle>
 				<itunes:summary>This week we sat down with the yayQuery hosts and discuss a bunch of topics.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3" length="11776418" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3" length="11776418" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3</guid>
 				<pubDate>Fri, 28 May 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:24:22</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -277,8 +277,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Nicholas Zakas is a front-end engineer at Yahoo and author of the new book High Performance JavaScript</itunes:subtitle>
 			<itunes:summary>This week we sat down with Nicholas Zakas to talk about High Performance JavaScript.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3" length="17526916" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-023-X-NicholasZakas.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3" length="17526916" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-023-X-NicholasZakas.mp3</guid>
 			<pubDate>Fri, 14 May 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:31:51</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -288,8 +288,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>James Senior is a Web Evengelist and we discuss Microsoft/jQuery and the new plugin proposals.</itunes:subtitle>
 				<itunes:summary>This week we sat down with James Senior a Web Technology evangelist at Microsoft and discussed jQuery/Microsoft.  We also announce Rey Bango as the new co-host of the show.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3" length="17526916" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3" length="17526916" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3</guid>
 				<pubDate>Fri, 7 May 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:36:21</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -299,8 +299,8 @@
 				<itunes:author>Ralph Whitbeck</itunes:author>
 				<itunes:subtitle>When Rey Bango comes on who knows what we will get.  Rey Bomb episode number 2.</itunes:subtitle>
 				<itunes:summary>This week we discuss JSConf, Rey's new position at Microsoft, Microsoft/jQuery relationship and jQuery Conference.  This is also the last show for Elijah and he is stepping down to spend more time with family.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3" length="17244972" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3" length="17244972" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3</guid>
 				<pubDate>Fri, 23 Apr 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:35:46</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -310,8 +310,8 @@
 				<itunes:author>Ralph Whitbeck</itunes:author>
 				<itunes:subtitle>Various jQuery and JavaScript related interviews from Barcamp Rochester</itunes:subtitle>
 				<itunes:summary>This week we provide you with three short interviews recorded at Barcamp Rochester earlier this month.  John Resig gives us an update on the state of jQuery.  Benjamin DeLillo tells us about a new WebGL library called WebGLU and Mich Cook of Yahoo introduces us to YUI3.  Show notes: http://blog.jquery.com/2010/04/16/the-official-jquery-podcast-episode-20-barcamp-rochester</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3" length="14180706 " type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3" length="14180706 " type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3</guid>
 				<pubDate>Fri, 16 Apr 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:29:22</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -321,8 +321,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 				<itunes:subtitle>The Authors of jQuery in Action</itunes:subtitle>
 				<itunes:summary>This week we talked with Yehuda Katz and Bear Bibeault about the upcoming second edition of the popular jQuery in Action book from Manning. Show notes: http://blog.jquery.com/2010/04/09/the-official-jquery-podcast-episode-19-jquery-in-action-2nd-ed</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3" length="15073913" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3" length="15073913" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3</guid>
 				<pubDate>Fri, 9 Apr 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:31:15</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -332,8 +332,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 				<itunes:subtitle>Jeffery Way, Editor of the site Nettuts</itunes:subtitle>
 				<itunes:summary>This week we talked with Jeffrey Way. He is the editor of Nettuts+, and the Site Manager of ThemeForest and CodeCanyon. Jeffrey gives an overview of the Nettuts+ website and explains why their tutorials focus so much on jQuery and gives some examples of recent jQuery related articles. Show notes: http://blog.jquery.com/2010/04/02/the-official-jquery-podcast-episode-18-jeffery-way-nettuts</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3" length="19157375" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3" length="19157375" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3</guid>
 				<pubDate>Fri, 2 Apr 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:39:45</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -343,8 +343,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 				<itunes:subtitle>jQuery UI team and the 1.8 release</itunes:subtitle>
 				<itunes:summary>We talked last week with the jQuery UI team right before the launch of jQuery UI 1.8, Richard D. Worth, Scott Gonzalez, Mike Hostetler and Doug Neiner filled in for Elijah.  We discuss the final release of jQuery UI 1.8.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3" length="18280287" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3" length="18280287" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3</guid>
 				<pubDate>Fri, 26 Mar 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:37:55</itunes:duration>
 				<itunes:keywords>jquery, jqueryui, javascript</itunes:keywords>
@@ -354,8 +354,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>jQuery Meetups, ideas for your events</itunes:subtitle>
 			<itunes:summary>We talk with Cody Lindley, Jonathan Sharp and Boaz Sender about meetups.jquery.com and try to help come up with ideas and process for hosting jQuery Meetups in your area.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3" length="11662948" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3" length="11662948" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3</guid>
 			<pubDate>Fri, 19 Mar 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:24:08</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -365,8 +365,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>John Resig joins in to discuss the last two point releases</itunes:subtitle>
 			<itunes:summary>We talk with John Resig about jQuery 1.4.1 and jQuery 1.4.2 as well as what's ahead in jQuery 1.4.3 and beyond.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3" length="21565476" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3" length="21565476" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3</guid>
 			<pubDate>Fri, 12 Mar 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:44:46</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -376,8 +376,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Phil Haack, Senior Program Manager for ASP.NET MVC at Microsoft</itunes:subtitle>
 			<itunes:summary>We talk with Phil Haack of Microsoft to talk about how jQuery is now included in Visual Studio and ASP.NET MVC and how easy it is to use.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3" length="28246112" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3" length="28246112" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3</guid>
 			<pubDate>Fri, 5 Mar 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:58:41</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -387,8 +387,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>David Walsh, Mootools developer talks about how Mootools and jQuery compare.</itunes:subtitle>
 			<itunes:summary>We talk with Mootools developer David Walsh and discuss the relationship between our teams and compare the libraries.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3" length="30735680" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3" length="30735680" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3</guid>
 			<pubDate>Fri, 26 Feb 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>01:03:52</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -398,8 +398,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Rey Bango, Cody Lindley, Karl Swedberg and Doug Neiner Talk jQuery</itunes:subtitle>
 			<itunes:summary>We talk about jQuery at a casual level and try to discuss some topics we normally wouldn't during an interview episode.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3" length="48838960" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3" length="48838960" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3</guid>
 			<pubDate>Fri, 19 Feb 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:50:48</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -409,8 +409,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>We talk with Yehuda Katz about Rails and jQuery.</itunes:subtitle>
 			<itunes:summary>Our last show while in Washington DC we sat down and talked with Yehuda Katz about Rails 3 and jQuery.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3" length="28399510" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3" length="28399510" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3</guid>
 			<pubDate>Fri, 12 Feb 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:29:30</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14, rails</itunes:keywords>
@@ -420,8 +420,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>appendTo's Mike Hostetler &amp; Jonathan Sharp talk about the new jQuery company</itunes:subtitle>
 			<itunes:summary>We took the opportunity to sit down with Mike Hostetler and Jonathon Sharp to discuss appendTo.  The first jQuery company that provides support, training and consultation at the Enterprise level.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3" length="36958889" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3" length="36958889" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3</guid>
 			<pubDate>Fri, 5 Feb 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:38:25</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14</itunes:keywords>
@@ -431,8 +431,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>David Artz, Director of Website Optimization at Aol.</itunes:subtitle>
 			<itunes:summary>We took the opportunity to sit down with David Artz and discuss how jQuery is used at Aol.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3" length="22683494" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3" length="22683494" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3.mp3</guid>
 			<pubDate>Fri, 29 Jan 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:23:33</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14</itunes:keywords>
@@ -442,8 +442,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Karl Swedberg and Paul Irish talk about the new api.jquery.com site.</itunes:subtitle>
 			<itunes:summary>The jQuery Documentation got a major facelift and was released during the 14 Days of jQuery.  Find out what's new in the site.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3" length="12632628" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3" length="12632628" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3</guid>
 			<pubDate>Fri, 22 Jan 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:26:09</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14</itunes:keywords>
@@ -453,8 +453,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>jQuery 1.4 is now released!</itunes:subtitle>
 			<itunes:summary>We are in Washington DC and we are all sitting face-to-face with John Resig as we talk about the jQuery 1.4 Release.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3" length="27839436" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3" length="27839436" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3</guid>
 			<pubDate>Fri, 15 Jan 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:28:55</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14</itunes:keywords>
@@ -464,8 +464,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Ben Alman, jQuery Plugin Developer and Core Contributor</itunes:subtitle>
 			<itunes:summary>We talk with Ben Alman about writing plugins and contributing to jQuery.  Elijah joins us after getting braces on, much hilarity ensues.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3" length="38173477" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3" length="38173477" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3</guid>
 			<pubDate>Fri, 08 Jan 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>01:19:22</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -475,7 +475,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Rey Bango, Head jQuery Evangelist</itunes:subtitle>
 			<itunes:summary>Rey Bango is the Head jQuery Evangelist, he talks with us about evangelism and what to expect in 2010.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3" length="24581443" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3" length="24581443" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3</guid>
 			<pubDate>Fri, 18 Dec 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>51:03</itunes:duration>
@@ -486,7 +486,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Cody Lindley, jQuery Enlightenment Author and jQuery Evangelist</itunes:subtitle>
 			<itunes:summary>Cody Lindley is the author of the e-book jQuery Enlightenment and the coauthor of jQuery Cookbook. Learn all about the recently released jQuery books.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3" length="29461536" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3" length="29461536" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3</guid>
 			<pubDate>Fri, 11 Dec 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>01:01:13</itunes:duration>
@@ -497,7 +497,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Paul Irish, yayQuery cohost and front-end developer</itunes:subtitle>
 			<itunes:summary>Paul Irish is a front-end developer and co-host of the other jQuery podcast called yayQuery.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3" length="34539110" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3" length="34539110" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3</guid>
 			<pubDate>Fri, 4 Dec 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>01:11:48</itunes:duration>
@@ -508,7 +508,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>jQuery UI Release Manager, Richard D. Worth</itunes:subtitle>
 			<itunes:summary>Richard D. Worth, Release Manager for the jQuery UI project joins us to explain jQuery UI and how you can contribute.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3" length="43090160" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3" length="43090160" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3</guid>
 			<pubDate>Fri, 20 Nov 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>01:29:37</itunes:duration>
@@ -519,7 +519,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Our first episode with guest John Resig</itunes:subtitle>
 			<itunes:summary>John Resig joins us on our first podcast to talk jQuery, the Software Freedom Conservancy, the upcoming 1.4 release and why Google Groups is dead.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3" length="36978091" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3" length="36978091" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3</guid>
 			<pubDate>Fri, 13 Nov 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>01:16:53</itunes:duration>

--- a/build_production/feed/jQueryPodcastShowNotes.xml
+++ b/build_production/feed/jQueryPodcastShowNotes.xml
@@ -31,7 +31,7 @@
 <span id="more-358"></span><br />
 </p>
 ]]></content:encoded>
-	<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" length="27949980" type="audio/mpeg" />
+	<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" length="27949980" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQCon &#8217;11: SF Bay Area &#8211; jQuery UI Keynote</title>
@@ -44,7 +44,7 @@
 		<description><![CDATA[This week we bring you the jQuery UI Keynote given by Richard Worth at the jQuery Conference 2011: San Francisco Bay Area. Rich presents the state of jQuery UI as well as provide a preview into the new Grid control project. You can subscribe to the show in iTunes or via the raw RSS feed [...]]]></description>
 		<content:encoded><![CDATA[<p>This week we bring you the jQuery UI Keynote given by Richard Worth at the jQuery Conference 2011: San Francisco Bay Area.  Rich presents the state of jQuery UI as well as provide a preview into the new Grid control project. </p>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" length="28509413" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" length="28509413" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQuery 1.5 &#8211; 1.6.1</title>
@@ -66,7 +66,7 @@
 <li><a href="https://developer.mozilla.org/en/DOM/window.mozRequestAnimationFrame">window.mozRequestAnimationFrame</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" length="26581160" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" length="26581160" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>RewardJS</title>
@@ -85,7 +85,7 @@
 <li><a href="http://jQueryUI.com">jQuery UI</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" length="17975180" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" length="17975180" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQCon &#8217;11: SF Bay Area &#8211; jQuery Mobile Keynote</title>
@@ -103,7 +103,7 @@
 <li><a href="http://filamentgroup.com/lab/slides_from_our_jquery_conference_presentation_on_jquery_mobile/">Slides</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" length="33597455" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" length="33597455" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQCon &#8217;11: SF Bay Area  &#8211; jQuery Keynote</title>
@@ -121,7 +121,7 @@
 <li><a href="http://www.slideshare.net/jeresig/jquery-keynote-spring-2011">Slides from the keynote</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" length="18742768" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" length="18742768" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>Wijmo</title>
@@ -141,7 +141,7 @@
 <li><a href="http://wijmo.com/wijmo-1-0-has-landed/">Wijmo 1.0 has landed</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" length="16034175" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" length="16034175" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQuery Mobile</title>
@@ -159,7 +159,7 @@
 <li><a href="http://jquerysummit.com">jQuery Summit</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" length="12344425" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" length="12344425" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQuery 1.4.3</title>
@@ -180,7 +180,7 @@
 <li><a href="http://code.jquery.com/jquery-1.4.4rc1.js">jQuery 1.4.4 RC 1</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" length="14397440" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" length="14397440" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>Ben Nadel</title>
@@ -206,7 +206,7 @@
 <li><a href="http://wijmo.com/">Wijmo jQuery UI Widgets</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" length="17577483" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" length="17577483" type="audio/mpeg" />
 		</item>
 	</channel>
 </rss>

--- a/source/_posts/episode-1.md
+++ b/source/_posts/episode-1.md
@@ -3,13 +3,13 @@ title: "1 - John Resig"
 date: "2009-11-13T08:00:00-05:00"
 slug: "announcing-the-official-jquery-podcast"
 path: "/2009/11/13/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3
 ---
 John Resig joins us on our first podcast to talk jQuery, the Software Freedom Conservancy, the upcoming 1.4 release and why Google Groups is dead.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-10.md
+++ b/source/_posts/episode-10.md
@@ -3,13 +3,13 @@ title: "10 - appendTo"
 date: "2010-02-05T08:00:00-05:00"
 slug: "episode-10-appendto-llc"
 path: "/2010/02/14/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3
 ---
 We took the opportunity to sit down with Mike Hostetler and Jonathon Sharp to discuss appendTo.  The first jQuery company that provides support, training and consultation at the Enterprise level.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-11.md
+++ b/source/_posts/episode-11.md
@@ -3,13 +3,13 @@ title: "11 - Yehuda Katz"
 date: "2010-02-12T08:00:00-05:00"
 slug: "episode-11-yehuda-katz"
 path: "/2010/02/15/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3
 ---
 Our last show while in Washington DC we sat down and talked with Yehuda Katz about Rails 3 and jQuery.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-12.md
+++ b/source/_posts/episode-12.md
@@ -3,13 +3,13 @@ title: "12 - Rey Bomb 1"
 date: "2010-02-19T08:00:00-05:00"
 slug: "episode-12-rey-bomb-1"
 path: "/2010/02/19/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3
 ---
 We talk about jQuery at a casual level and try to discuss some topics we normally wouldn&#039;t during an interview episode.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-13.md
+++ b/source/_posts/episode-13.md
@@ -3,13 +3,13 @@ title: "13 - David Walsh"
 date: "2010-02-26T08:00:00-05:00"
 slug: "episode-13-david-walsh"
 path: "/2010/02/26/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3
 ---
 We talk with Mootools developer David Walsh and discuss the relationship between our teams and compare the libraries.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-14.md
+++ b/source/_posts/episode-14.md
@@ -3,13 +3,13 @@ title: "14 - Phil Haack"
 date: "2010-03-05T08:00:00-05:00"
 slug: "episode-14-phil-haack"
 path: "/2010/03/05/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3
 ---
 We talk with Phil Haack of Microsoft to talk about how jQuery is now included in Visual Studio and ASP.NET MVC and how easy it is to use.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-15.md
+++ b/source/_posts/episode-15.md
@@ -3,13 +3,13 @@ title: "15 - John Resig (1.4.1 - 1.4.2)"
 date: "2010-03-12T08:00:00-05:00"
 slug: "episode-15-john-resig-jquery-1-4-1-1-4-2"
 path: "/2010/03/12/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3
 ---
 We talk with John Resig about jQuery 1.4.1 and jQuery 1.4.2 as well as what&#039;s ahead in jQuery 1.4.3 and beyond.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3" controls=""></audio>
 
 
 ## Interview

--- a/source/_posts/episode-16.md
+++ b/source/_posts/episode-16.md
@@ -3,13 +3,13 @@ title: "16 - jQuery Meetups"
 date: "2010-03-19T08:00:00-05:00"
 slug: "episode-16-jquery-meetups"
 path: "/2010/03/19/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3
 ---
 We talk with Cody Lindley, Jonathan Sharp and Boaz Sender about meetups.jquery.com and try to help come up with ideas and process for hosting jQuery Meetups in your area.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-17.md
+++ b/source/_posts/episode-17.md
@@ -3,13 +3,13 @@ title: "17 - jQuery UI 1.8"
 date: "2010-03-26T08:00:00-05:00"
 slug: "episode-17-jquery-ui-1-8"
 path: "/2010/03/26/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3
 ---
 We talked last week with the jQuery UI team right before the launch of jQuery UI 1.8, Richard D. Worth, Scott Gonzalez, Mike Hostetler and Doug Neiner filled in for Elijah.  We discuss the final release of jQuery UI 1.8.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-18.md
+++ b/source/_posts/episode-18.md
@@ -3,7 +3,7 @@ title: "18 - Jeffery Way (Nettuts)"
 date: "2010-04-02T08:00:00-05:00"
 slug: "episode-18-jeffery-way-nettuts"
 path: "/2010/04/02/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3
 ---
 This week we talked with Jeffrey Way. He is the editor of Nettuts+, and the Site Manager of ThemeForest and CodeCanyon. Jeffrey gives an overview of the Nettuts+ website and explains why their tutorials focus so much on jQuery and gives some examples of recent jQuery related articles.
 
@@ -11,7 +11,7 @@ We also announce the winner of the [Nettuts giveaway](http://web.archive.org/web
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-19.md
+++ b/source/_posts/episode-19.md
@@ -3,13 +3,13 @@ title: "19 - jQuery in Action, 2nd Ed."
 date: "2010-04-09T08:00:00-05:00"
 slug: "episode-19-jquery-in-action-2nd-ed"
 path: "/2010/04/09/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3
 ---
 This week we talked with Yehuda Katz and Bear Bibeault about the upcoming second edition of the popular jQuery in Action book from Manning.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-2.md
+++ b/source/_posts/episode-2.md
@@ -3,13 +3,13 @@ title: "2 - Richard D. Worth"
 date: "2009-11-20T08:00:00-05:00"
 slug: "episode-2-richard-d-worth"
 path: "/2009/11/20/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3
 ---
 Richard D. Worth, Release Manager for the jQuery UI project joins us to explain jQuery UI and how you can contribute.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3" controls=""></audio>
 
 ## Links from the show…
 

--- a/source/_posts/episode-20.md
+++ b/source/_posts/episode-20.md
@@ -3,13 +3,13 @@ title: "20 - Barcamp Rochester"
 date: "2010-04-16T08:00:00-05:00"
 slug: "episode-20-barcamp-rochester"
 path: "/2010/04/16/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3
 ---
 This week we provide you with three short interviews recorded at Barcamp Rochester earlier this month.  John Resig gives us an update on the state of jQuery.  Benjamin DeLillo tells us about a new WebGL library called WebGLU and Mich Cook of Yahoo introduces us to YUI3.
 
 Host: Ralph Whitbeck.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3" controls=""></audio>
 
 ## Interviews
 

--- a/source/_posts/episode-21.md
+++ b/source/_posts/episode-21.md
@@ -3,13 +3,13 @@ title: "21 - Rey Bomb 2"
 date: "2010-04-23T08:00:00-05:00"
 slug: "episode-21-rey-bomb-2"
 path: "/2010/04/24/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3
 ---
 This week we discuss JSConf, Rey&#039;s new position at Microsoft, Microsoft/jQuery relationship and jQuery Conference.  This is also the last show for Elijah and he is stepping down to spend more time with family.
 
 Host: Ralph Whitbeck.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-22.md
+++ b/source/_posts/episode-22.md
@@ -3,13 +3,13 @@ title: "22 - James Senior"
 date: "2010-05-07T08:00:00-05:00"
 slug: "episode-22-james-senior"
 path: "/2010/05/07/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3
 ---
 This week we sat down with James Senior a Web Technology evangelist at Microsoft and discussed jQuery/Microsoft.  We also announce Rey Bango as the new co-host of the show.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-23.md
+++ b/source/_posts/episode-23.md
@@ -3,13 +3,13 @@ title: "23 - Nicholas Zakas"
 date: "2010-05-14T08:00:00-05:00"
 slug: "episode-23-nicholas-zakas"
 path: "/2010/05/18/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3
 ---
 This week we sat down with Nicholas Zakas to talk about High Performance JavaScript.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-24.md
+++ b/source/_posts/episode-24.md
@@ -3,13 +3,13 @@ title: "24 - yayQuery"
 date: "2010-05-28T08:00:00-05:00"
 slug: "episode-24-yayquery"
 path: "/2010/05/28/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3
 ---
 This week we sat down with the yayQuery hosts and discuss a bunch of topics.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-25.md
+++ b/source/_posts/episode-25.md
@@ -3,13 +3,13 @@ title: "25 - Meeno Van Slooten"
 date: "2010-06-04T08:00:00-05:00"
 slug: "episode-25-menno-van-slooten"
 path: "/2010/06/04/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3
 ---
 This week we sat down with Meeno Van Slooten who was a speaker at the Bay Area jQuery Conference 2010 and showed off a cool new UI Testing Framework he developed.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-26.md
+++ b/source/_posts/episode-26.md
@@ -3,13 +3,13 @@ title: "26 - Remy Sharp pt. 1 (jsbin.com)"
 date: "2010-06-11T08:00:00-05:00"
 slug: "episode-26-remy-sharp-part-1"
 path: "/2010/06/11/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3
 ---
 This week we sat down and talked with Remy Sharp and discussed jsbin.com a site to try out and share HTML and JavaScript quickly and easily.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-27.md
+++ b/source/_posts/episode-27.md
@@ -3,13 +3,13 @@ title: "27 - Remy Sharp pt. 2 (HTML5)"
 date: "2010-06-18T08:00:00-05:00"
 slug: "episode-27-remy-sharp-part-2"
 path: "/2010/06/18/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3
 ---
 This week we sat down and talked with Remy Sharp and discussed HTML5.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-28.md
+++ b/source/_posts/episode-28.md
@@ -3,13 +3,13 @@ title: "28 - Remy Sharp pt. 3 (jQuery for Designers)"
 date: "2010-06-25T08:00:00-05:00"
 slug: "episode-28-remy-sharp-part-3-jquery-for-designers"
 path: "/2010/06/25/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3
 ---
 This week we sat down and talked with Remy Sharp and discussed jQuery for Designers, Full Frontal JavaScript Conference, Snap Bird and have a little fun.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-29.md
+++ b/source/_posts/episode-29.md
@@ -3,13 +3,13 @@ title: "29 - Rey Bomb 3"
 date: "2010-07-09T08:00:00-05:00"
 slug: "episode-29-rey-bomb-3"
 path: "/2010/07/09/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3
 ---
 We talk about a new front-end focused tutorial site, Script Junkies and we talk about the mobile strategy of jQuery.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-3.md
+++ b/source/_posts/episode-3.md
@@ -3,14 +3,14 @@ title: "3 - Paul Irish"
 date: "2009-12-04T08:00:00-05:00"
 slug: "episode-3-paul-irish"
 path: "/2009/12/04/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3
 overcast_id: 9924925298570
 ---
 Paul Irish is a front-end developer and co-host of the other jQuery podcast called yayQuery.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3" controls=""></audio>
 
 ## Links from the show
 

--- a/source/_posts/episode-30.md
+++ b/source/_posts/episode-30.md
@@ -3,13 +3,13 @@ title: "30 - Chris Coyier"
 date: "2010-07-30T08:00:00-05:00"
 slug: "episode-30-chris-coyier"
 path: "/2010/07/30/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3
 ---
 We talk to Chris Coyier about jQuery, css-tricks.com and Wufoo .
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-31.md
+++ b/source/_posts/episode-31.md
@@ -3,13 +3,13 @@ title: "31 - Filament Group"
 date: "2010-08-13T08:00:00-05:00"
 slug: "episode-31-filament-group"
 path: "/2010/08/19/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3
 ---
 We talk to the folks at Filament Group about Progressive Enhancement, jQuery UI and Mobile..
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-32.md
+++ b/source/_posts/episode-32.md
@@ -3,13 +3,13 @@ title: "32 - Dave Ward"
 date: "2010-08-27T08:00:00-05:00"
 slug: "episode-32-dave-ward"
 path: "/2010/08/27/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3
 ---
 Talk with Dave Ward about the Master jQuery series on Tekpub and caching on Google CDN, etc.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-33.md
+++ b/source/_posts/episode-33.md
@@ -3,13 +3,13 @@ title: "33 - Karl Swedberg pt. 1"
 date: "2010-09-10T08:00:00-05:00"
 slug: "karl-swedberg-part-1"
 path: "/2010/09/10/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3
 ---
 Karl Swedberg joins us this week to chat about the community needs of jQuery and what we know now nine months after api.jquery.com has launched.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-34.md
+++ b/source/_posts/episode-34.md
@@ -3,13 +3,13 @@ title: "34 - Karl Swedberg pt. 2"
 date: "2010-09-17T08:00:00-05:00"
 slug: "episode-34-karl-swedberg-part-2"
 path: "/2010/09/17/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3
 ---
 Karl Swedberg joins us again this week to chat about Learning jQuery and the upcoming jQuery conference.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-35.md
+++ b/source/_posts/episode-35.md
@@ -3,13 +3,13 @@ title: "35 - jQuery UI 1.8.5"
 date: "2010-09-30T08:00:00-05:00"
 slug: "episode-35-jquery-ui-1-8-5"
 path: "/2010/09/30/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3
 ---
 Scott González, Lead Developer for jQuery UI joins us to talk about the latest release of jQuery UI and the road ahead.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-36.md
+++ b/source/_posts/episode-36.md
@@ -3,13 +3,13 @@ title: "36 - Bocoup"
 date: "2010-10-06T08:00:00-05:00"
 slug: "episode-36-bocoup"
 path: "/2010/10/06/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3
 ---
 We sit down with Boaz Sender and Ben Alman who both work for Bocoup in Boston, MA.  We discuss Bocoup from their clients to their open source contributions.  Bocoup is providing the pre-conference training in Boston and we talk about the training class and the advance classes that are also offered.  Bocoup Loft also hosts many events including jQuery Meetups in Boston.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-37.md
+++ b/source/_posts/episode-37.md
@@ -3,13 +3,13 @@ title: "37 - Ben Nadel"
 date: "2010-10-22T08:00:00-05:00"
 slug: "episode-37-ben-nadel"
 path: "/2010/10/22/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3
 ---
 Fresh off the jQuery Conference 2010: Boston, we sit down with Ben Nadel and talk about the conference.  Ben tells us about what he learned and tells us about the awesome photo he got with the jQuery Community.  Ben’s a jQuery spokesperson for the Cold Fusion community and we talk about that as well.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" controls=""></audio>
 
 ## Links from the show
 

--- a/source/_posts/episode-38.md
+++ b/source/_posts/episode-38.md
@@ -3,13 +3,13 @@ title: "38 - jQuery 1.4.3"
 date: "2010-10-29T08:00:00-05:00"
 slug: "episode-38-jquery-1-4-3"
 path: "/2010/10/29/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3
 ---
 John Resig joins us to talk about the latest jQuery release, 1.4.3.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" controls=""></audio>
 
 John Resig joins us this week to talk about the lastest jQuery release, 1.4.3. We go over some of the performance improvements, the CSS method rewrite, new data method additions amongst others. Find out everything you need to know about this release right here. Also find out details about how to get started testing the 1.4.4 RC.
 

--- a/source/_posts/episode-39.md
+++ b/source/_posts/episode-39.md
@@ -3,13 +3,13 @@ title: "39 - jQuery Mobile"
 date: "2010-11-09T08:00:00-05:00"
 slug: "episode-39-jquery-mobile"
 path: "/2010/11/10/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3
 ---
 John Resig joins us to talk about jQuery Mobile.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" controls=""></audio>
 
 ## Description
 

--- a/source/_posts/episode-4.md
+++ b/source/_posts/episode-4.md
@@ -3,13 +3,13 @@ title: "4 - Cody Lindley"
 date: "2009-12-11T08:00:00-05:00"
 slug: "episode-4-cody-lindley"
 path: "/2009/12/11/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3
 ---
 Cody Lindley is the author of the e-book jQuery Enlightenment and the coauthor of jQuery Cookbook. Learn all about the recently released jQuery books.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3" controls=""></audio>
 
 ## This Week in jQuery
 

--- a/source/_posts/episode-40.md
+++ b/source/_posts/episode-40.md
@@ -3,13 +3,13 @@ title: "40 - Wijmo"
 date: "2010-12-16T08:00:00-05:00"
 slug: "episode-40-wijmo"
 path: "/2010/12/17/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3
 ---
 Chris Bannon from ComponentOne talks about Wijmo a new UI Library based on jQuery UI.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-41.md
+++ b/source/_posts/episode-41.md
@@ -3,13 +3,13 @@ title: "41 - jQuery Keynote"
 date: "2011-04-22T08:00:00-05:00"
 slug: "episode-41-jquery-keynote"
 path: "/2011/04/22/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3
 ---
 John Resig delivers the jQuery Keynote from the jQuery Conference 2011: SF Bay Area. Follow along with the slides.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" controls=""></audio>
 
 ## Description
 

--- a/source/_posts/episode-42.md
+++ b/source/_posts/episode-42.md
@@ -3,13 +3,13 @@ title: "42 - jQuery Mobile Keynote"
 date: "2011-04-29T08:00:00-05:00"
 slug: "episode-42-jquery-mobile-keynote"
 path: "/2011/04/29/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3
 ---
 Todd Parker and Scott Jehl deliver the jQuery Mobile keynote from the jQuery Conference 2011: SF BAy Area. Follow along with the slides.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" controls=""></audio>
 
 ## Description
 

--- a/source/_posts/episode-43.md
+++ b/source/_posts/episode-43.md
@@ -3,13 +3,13 @@ title: "43 - RewardJS"
 date: "2011-05-10T08:00:00-05:00"
 slug: "rewardjs"
 path: "/2011/05/11/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3
 ---
 Talk with Richard D. Worth about his personal project RewardJS to reward developers to fix bugs.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-44.md
+++ b/source/_posts/episode-44.md
@@ -3,13 +3,13 @@ title: "44 - jQuery 1.5 - 1.6.1"
 date: "2011-05-13T08:00:00-05:00"
 slug: "jquery-1-5-1-6-1"
 path: "/2011/05/13/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3
 ---
 We talk with jQuery Core Team Member Dave Methvin about the last few releases.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" controls=""></audio>
 
 ## Description
 

--- a/source/_posts/episode-45.md
+++ b/source/_posts/episode-45.md
@@ -3,13 +3,13 @@ title: "45 - jQuery UI Keynote"
 date: "2011-05-20T08:00:00-05:00"
 slug: "jqcon-11-sf-bay-area-jquery-ui-keynote"
 path: "/2011/05/20/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3
 ---
 Richard D. Worth presents the state of jQuery UI and a preview of the jQuery UI Grid project from the jQuery Conference 2011: San Francisco Bay Area.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" controls=""></audio>
 
 ## Description
 

--- a/source/_posts/episode-46.md
+++ b/source/_posts/episode-46.md
@@ -3,13 +3,13 @@ title: "46 - Q&A Panel from jQCon"
 date: "2011-06-07T08:00:00-05:00"
 slug: "jqcon-11-sf-bay-area-panel-q-a"
 path: "/2011/06/07/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3
 ---
 John Resig, Richard Worth, Adam Sontag, Dan Heberden, Leah Silber and Scott Jehl answers questions from the audience at jQuery Conference 2011 in San Francisco.
 
 Host: Ralph Whitbeck &amp; Rey Bango.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" controls=""></audio>
 
 ## Description
 

--- a/source/_posts/episode-5.md
+++ b/source/_posts/episode-5.md
@@ -3,13 +3,13 @@ title: "5 - Rey Bango"
 date: "2009-12-18T08:00:00-05:00"
 slug: "episode-5-rey-bango"
 path: "/2010/01/01/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3
 ---
 Rey Bango is the Head jQuery Evangelist, he talks with us about evangelism and what to expect in 2010.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3" controls=""></audio>
 
 ## Links from the show
 

--- a/source/_posts/episode-6.md
+++ b/source/_posts/episode-6.md
@@ -3,13 +3,13 @@ title: "6 - Ben Alman"
 date: "2010-01-08T08:00:00-05:00"
 slug: "episode-6-ben-alman"
 path: "/2010/01/10/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3
 ---
 We talk with Ben Alman about writing plugins and contributing to jQuery.  Elijah joins us after getting braces on, much hilarity ensues.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-7.md
+++ b/source/_posts/episode-7.md
@@ -3,13 +3,13 @@ title: "7 - jQuery 1.4 (John Resig)"
 date: "2010-01-15T08:00:00-05:00"
 slug: "episode-7-jquery-1-4-release-john-resig"
 path: "/2010/01/15/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3
 ---
 We are in Washington DC and we are all sitting face-to-face with John Resig as we talk about the jQuery 1.4 Release.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-8.md
+++ b/source/_posts/episode-8.md
@@ -3,13 +3,13 @@ title: "8 - api.jquery.com"
 date: "2010-01-22T08:00:00-05:00"
 slug: "episode-8-api-jquery-com"
 path: "/2010/01/22/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3
 ---
 The jQuery Documentation got a major facelift and was released during the 14 Days of jQuery. In this episode we are at the Aol headquarters in Washington DC filming video and releasing jQuery 1.4 for the 14 Days of jQuery. In this episode we talk with Karl Swedberg and Paul Irish about the new [api.jquery.com](http://api.jquery.com) documentation site.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3" controls=""></audio>
 
 ## Interview
 

--- a/source/_posts/episode-9.md
+++ b/source/_posts/episode-9.md
@@ -3,13 +3,13 @@ title: "9 - David Artz, Aol."
 date: "2010-01-29T08:00:00-05:00"
 slug: "episode-9-david-artz-aol"
 path: "/2010/01/29/{slug}/"
-enclosure: http://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3
+enclosure: https://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3
 ---
 We took the opportunity to sit down with David Artz and discuss how jQuery is used at Aol.
 
 Host: Ralph Whitbeck &amp; Elijah Manor.
 
-<audio src="http://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3" controls=""></audio>
+<audio src="https://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3" controls=""></audio>
 
 
 ## Interview

--- a/source/feed/jQueryPodcast.xml
+++ b/source/feed/jQueryPodcast.xml
@@ -24,8 +24,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>John Resig, Richard Worth, Adam Sontag, Dan Heberden, Leah Silber and Scott Jehl answers questions from the audience at jQuery Conference 2011 in San Francisco.</itunes:subtitle>
 			<itunes:summary>John Resig, Richard Worth, Adam Sontag, Dan Heberden, Leah Silber and Scott Jehl answers questions from the audience at jQuery Conference 2011 in San Francisco.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" length="27949980" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" length="27949980" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3</guid>
 			<pubDate>Tue, 7 Jun 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:58:04</itunes:duration>
 			<itunes:keywords>jquery, jquery ui</itunes:keywords>
@@ -35,8 +35,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Richard D. Worth presents the state of jQuery UI and a preview of the jQuery UI Grid project from the jQuery Conference 2011: San Francisco Bay Area.</itunes:subtitle>
 			<itunes:summary>Richard D. Worth presents the state of jQuery UI and a preview of the jQuery UI Grid project from the jQuery Conference 2011: San Francisco Bay Area.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" length="28509413" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" length="28509413" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3</guid>
 			<pubDate>Fri, 20 May 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:59:14</itunes:duration>
 			<itunes:keywords>jquery, jquery ui</itunes:keywords>
@@ -46,8 +46,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>We talk with jQuery Core Team Member Dave Methvin about the last few releases.</itunes:subtitle>
 			<itunes:summary>We talk with jQuery Core Team Member Dave Methvin about the last few releases.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" length="26581160" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" length="26581160" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3</guid>
 			<pubDate>Fri, 13 May 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:55:13</itunes:duration>
 			<itunes:keywords>jquery</itunes:keywords>
@@ -57,8 +57,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Talk with Richard D. Worth about his personal project RewardJS to reward developers to fix bugs.</itunes:subtitle>
 			<itunes:summary>Talk with Richard D. Worth about his personal project RewardJS to reward developers to fix bugs.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" length="17975180" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" length="17975180" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3</guid>
 			<pubDate>Tue, 10 May 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:37:17</itunes:duration>
 			<itunes:keywords>rewardjs, jquery ui</itunes:keywords>
@@ -68,8 +68,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Todd Parker and Scott Jehl deliver the jQuery Mobile keynote from the jQuery Conference 2011: SF BAy Area. Follow along with the slides at http://filamentgroup.com/lab/slides_from_our_jquery_conference_presentation_on_jquery_mobile/</itunes:subtitle>
 			<itunes:summary>Todd Parker and Scott Jehl deliver the jQuery Mobile keynote from the jQuery Conference 2011: SF BAy Area. Follow along with the slides at http://filamentgroup.com/lab/slides_from_our_jquery_conference_presentation_on_jquery_mobile/</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" length="33597455" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" length="33597455" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3</guid>
 			<pubDate>Fri, 29 Apr 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>01:09:50</itunes:duration>
 			<itunes:keywords>jquery, jquery mobile, javascript</itunes:keywords>
@@ -79,8 +79,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>John Resig delivers the jQuery Keynote from the jQuery Conference 2011: SF Bay Area</itunes:subtitle>
 			<itunes:summary>John Resig delivers the jQuery Keynote from the jQuery Conference 2011: SF Bay Area. Follow along with John's slides at http://www.slideshare.net/jeresig/jquery-keynote-spring-2011</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" length="18742768" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-041-jQCon1SFjQueryKeynote.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" length="18742768" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-041-jQCon1SFjQueryKeynote.mp3</guid>
 			<pubDate>Fri, 22 Apr 2011 08:00:00 -0500</pubDate>
 			<itunes:duration>00:38:53</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -90,8 +90,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Chris Bannon from ComponentOne talks about Wijmo a new UI Library based on jQuery UI.</itunes:subtitle>
 			<itunes:summary>Chris Bannon from ComponentOne talks about Wijmo a new UI Library based on jQuery UI.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" length="16034175" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" length="16034175" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3</guid>
 			<pubDate>Thu, 16 Dec 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:33:15</itunes:duration>
 			<itunes:keywords>jquery, javascript, wijmo</itunes:keywords>
@@ -101,8 +101,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>John Resig joins us to talk about jQuery Mobile.</itunes:subtitle>
 				<itunes:summary>John Resig joins us to talk about jQuery Mobile.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" length="12344425" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" length="12344425" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3</guid>
 				<pubDate>Tue, 9 Nov 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:25:33</itunes:duration>
 				<itunes:keywords>jquery, javascript, mobile</itunes:keywords>
@@ -112,8 +112,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>John Resig joins us to talk about the latest jQuery release, 1.4.3.</itunes:subtitle>
 				<itunes:summary>John Resig joins us to talk about the latest jQuery release, 1.4.3.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" length="14397440" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" length="14397440" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3</guid>
 				<pubDate>Fri, 29 Oct 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:29:50</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -123,8 +123,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>We sit down with Ben Nadel and discuss Cold Fusion and the jQuery Conference this past weekend.</itunes:subtitle>
 				<itunes:summary>Fresh off the jQuery Conference 2010: Boston, we sit down with Ben Nadel and talk about the conference.  Ben tells us about what he learned and tells us about the awesome photo he got with the jQuery Community.  Ben’s a jQuery spokesperson for the Cold Fusion community and we talk about that as well.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" length="17577483" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" length="17577483" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3</guid>
 				<pubDate>Fri, 22 Oct 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:36:28</itunes:duration>
 				<itunes:keywords>jquery, javascript, jqcon</itunes:keywords>
@@ -134,8 +134,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>We sit down with Boaz Sender and Ben Alman who both work for Bocoup in Boston, MA.  We discuss Bocoup from their clients to their open source contributions.</itunes:subtitle>
 				<itunes:summary>We sit down with Boaz Sender and Ben Alman who both work for Bocoup in Boston, MA.  We discuss Bocoup from their clients to their open source contributions.  Bocoup is providing the pre-conference training in Boston and we talk about the training class and the advance classes that are also offered.  Bocoup Loft also hosts many events including jQuery Meetups in Boston.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3" length="20560458" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3" length="20560458" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-036-Bocoup.mp3</guid>
 				<pubDate>Wed, 6 Oct 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:42:40</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -145,8 +145,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Scott González, Lead Developer for jQuery UI joins us to talk about the latest release of jQuery UI and the road ahead.</itunes:subtitle>
 				<itunes:summary>Scott González, Lead Developer for jQuery UI joins us to talk about the latest release of jQuery UI and the road ahead.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3" length="23197153" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3" length="23197153" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-035-jQueryUI185.mp3</guid>
 				<pubDate>Thu, 30 Sep 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:48:10</itunes:duration>
 				<itunes:keywords>jquery, javascript, jQuery ui</itunes:keywords>
@@ -156,8 +156,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Karl Swedberg joins us again this week to chat about Learning jQuery and the upcoming jQuery conference.</itunes:subtitle>
 				<itunes:summary>Karl Swedberg joins us again this week to chat about Learning jQuery and the upcoming jQuery conference.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3" length="15985484" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3" length="15985484" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-034-KarlSwedbergpt2.mp3</guid>
 				<pubDate>Fri, 17 Sep 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:33:09</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -167,8 +167,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Karl Swedberg joins us this week to chat about the community needs of jQuery and what we know now nine months after api.jquery.com has launched.</itunes:subtitle>
 				<itunes:summary>Karl Swedberg joins us this week to chat about the community needs of jQuery and what we know now nine months after api.jquery.com has launched.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3" length="17517715" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3" length="17517715" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-033-KarlSwedbergpt1.mp3</guid>
 				<pubDate>Fri, 10 Sep 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:36:20</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -178,8 +178,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Dave Ward co host of the video series on Tekpub called Master jQuery</itunes:subtitle>
 				<itunes:summary>Talk with Dave Ward about the Master jQuery series on Tekpub and caching on Google CDN, etc.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3" length="20597656" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3" length="20597656" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-032-DaveWard.mp3</guid>
 				<pubDate>Fri, 27 Aug 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:42:45</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -189,8 +189,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Filament Group, discussing Progressive Enhancement, jQuery UI and Mobile.</itunes:subtitle>
 				<itunes:summary>We talk to the folks at Filament Group about Progressive Enhancement, jQuery UI and Mobile..</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3" length="21193248" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3" length="21193248" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-031-FilamentGroup.mp3</guid>
 				<pubDate>Fri, 13 Aug 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:44:00</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -200,8 +200,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Chris Coyier of css-tricks.com and Wufoo.</itunes:subtitle>
 				<itunes:summary>We talk to Chris Coyier about jQuery, css-tricks.com and Wufoo .</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3" length="27720517" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3" length="27720517" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-030-ChrisCoyier.mp3</guid>
 				<pubDate>Fri, 30 Jul 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:57:35</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -211,8 +211,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>The guys get together and discuss Script Junkie and Mobile jQuery.</itunes:subtitle>
 				<itunes:summary>We talk about a new front-end focused tutorial site, Script Junkies and we talk about the mobile strategy of jQuery.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3" length="22034182" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3" length="22034182" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-029-ReyBomb3.mp3</guid>
 				<pubDate>Fri, 9 Jul 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:45:45</itunes:duration>
 				<itunes:keywords>jquery, javascript, mobile</itunes:keywords>
@@ -222,8 +222,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Remy Sharp, jQuery Developer Relations Team member and jsbin.com creator</itunes:subtitle>
 				<itunes:summary>This week we sat down and talked with Remy Sharp and discussed jQuery for Designers, Full Frontal JavaScript Conference, Snap Bird and have a little fun.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3" length="18372271" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3" length="18372271" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-028-RemySharp3JfD.mp3</guid>
 				<pubDate>Fri, 25 Jun 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:38:07</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -233,8 +233,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Remy Sharp, jQuery Developer Relations Team member and jsbin.com creator</itunes:subtitle>
 				<itunes:summary>This week we sat down and talked with Remy Sharp and discussed HTML5.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3" length="14077493" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3" length="14077493" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-027-RemySharp2html5.mp3</guid>
 				<pubDate>Fri, 18 Jun 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:29:10</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -244,8 +244,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Remy Sharp, jQuery Developer Relations Team member and jsbin.com creator</itunes:subtitle>
 				<itunes:summary>This week we sat down and talked with Remy Sharp and discussed jsbin.com a site to try out and share HTML and JavaScript quickly and easily.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3" length="14539338" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3" length="14539338" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-026-RemySharp1jsbin.mp3</guid>
 				<pubDate>Fri, 11 Jun 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:30:08</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -255,8 +255,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>Meeno Van Slooten was a speaker at the Bay Area jQuery Conference 2010 and showed off a cool new UI Testing Framework he developed.</itunes:subtitle>
 				<itunes:summary>This week we sat down with Meeno Van Slooten who was a speaker at the Bay Area jQuery Conference 2010 and showed off a cool new UI Testing Framework he developed.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3" length="11597741 " type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3" length="11597741 " type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-025-MeenoVanSlooten.mp3</guid>
 				<pubDate>Fri, 4 Jun 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:24:00</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -266,8 +266,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>The hosts of the yayQuery podcast talk with Rey and Ralph.</itunes:subtitle>
 				<itunes:summary>This week we sat down with the yayQuery hosts and discuss a bunch of topics.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3" length="11776418" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3" length="11776418" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-024-yayQuery.mp3</guid>
 				<pubDate>Fri, 28 May 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:24:22</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -277,8 +277,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 			<itunes:subtitle>Nicholas Zakas is a front-end engineer at Yahoo and author of the new book High Performance JavaScript</itunes:subtitle>
 			<itunes:summary>This week we sat down with Nicholas Zakas to talk about High Performance JavaScript.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3" length="17526916" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-023-X-NicholasZakas.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-023-NicholasZakas.mp3" length="17526916" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-023-X-NicholasZakas.mp3</guid>
 			<pubDate>Fri, 14 May 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:31:51</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -288,8 +288,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Rey Bango</itunes:author>
 				<itunes:subtitle>James Senior is a Web Evengelist and we discuss Microsoft/jQuery and the new plugin proposals.</itunes:subtitle>
 				<itunes:summary>This week we sat down with James Senior a Web Technology evangelist at Microsoft and discussed jQuery/Microsoft.  We also announce Rey Bango as the new co-host of the show.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3" length="17526916" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3" length="17526916" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-022-JamesSenior.mp3</guid>
 				<pubDate>Fri, 7 May 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:36:21</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -299,8 +299,8 @@
 				<itunes:author>Ralph Whitbeck</itunes:author>
 				<itunes:subtitle>When Rey Bango comes on who knows what we will get.  Rey Bomb episode number 2.</itunes:subtitle>
 				<itunes:summary>This week we discuss JSConf, Rey's new position at Microsoft, Microsoft/jQuery relationship and jQuery Conference.  This is also the last show for Elijah and he is stepping down to spend more time with family.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3" length="17244972" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3" length="17244972" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-021-ReyBomb2.mp3</guid>
 				<pubDate>Fri, 23 Apr 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:35:46</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -310,8 +310,8 @@
 				<itunes:author>Ralph Whitbeck</itunes:author>
 				<itunes:subtitle>Various jQuery and JavaScript related interviews from Barcamp Rochester</itunes:subtitle>
 				<itunes:summary>This week we provide you with three short interviews recorded at Barcamp Rochester earlier this month.  John Resig gives us an update on the state of jQuery.  Benjamin DeLillo tells us about a new WebGL library called WebGLU and Mich Cook of Yahoo introduces us to YUI3.  Show notes: http://blog.jquery.com/2010/04/16/the-official-jquery-podcast-episode-20-barcamp-rochester</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3" length="14180706 " type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3" length="14180706 " type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-020-BarcampRochester.mp3</guid>
 				<pubDate>Fri, 16 Apr 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:29:22</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -321,8 +321,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 				<itunes:subtitle>The Authors of jQuery in Action</itunes:subtitle>
 				<itunes:summary>This week we talked with Yehuda Katz and Bear Bibeault about the upcoming second edition of the popular jQuery in Action book from Manning. Show notes: http://blog.jquery.com/2010/04/09/the-official-jquery-podcast-episode-19-jquery-in-action-2nd-ed</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3" length="15073913" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3" length="15073913" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-019-jQueryInAction.mp3</guid>
 				<pubDate>Fri, 9 Apr 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:31:15</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -332,8 +332,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 				<itunes:subtitle>Jeffery Way, Editor of the site Nettuts</itunes:subtitle>
 				<itunes:summary>This week we talked with Jeffrey Way. He is the editor of Nettuts+, and the Site Manager of ThemeForest and CodeCanyon. Jeffrey gives an overview of the Nettuts+ website and explains why their tutorials focus so much on jQuery and gives some examples of recent jQuery related articles. Show notes: http://blog.jquery.com/2010/04/02/the-official-jquery-podcast-episode-18-jeffery-way-nettuts</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3" length="19157375" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3" length="19157375" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-018-JefferyWay.mp3</guid>
 				<pubDate>Fri, 2 Apr 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:39:45</itunes:duration>
 				<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -343,8 +343,8 @@
 				<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 				<itunes:subtitle>jQuery UI team and the 1.8 release</itunes:subtitle>
 				<itunes:summary>We talked last week with the jQuery UI team right before the launch of jQuery UI 1.8, Richard D. Worth, Scott Gonzalez, Mike Hostetler and Doug Neiner filled in for Elijah.  We discuss the final release of jQuery UI 1.8.</itunes:summary>
-				<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3" length="18280287" type="audio/mpeg" />
-				<guid>http://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3</guid>
+				<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3" length="18280287" type="audio/mpeg" />
+				<guid>https://content.jquery.com/podcast/jQueryPodcast-017-jQueryUI18.mp3</guid>
 				<pubDate>Fri, 26 Mar 2010 08:00:00 -0500</pubDate>
 				<itunes:duration>00:37:55</itunes:duration>
 				<itunes:keywords>jquery, jqueryui, javascript</itunes:keywords>
@@ -354,8 +354,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>jQuery Meetups, ideas for your events</itunes:subtitle>
 			<itunes:summary>We talk with Cody Lindley, Jonathan Sharp and Boaz Sender about meetups.jquery.com and try to help come up with ideas and process for hosting jQuery Meetups in your area.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3" length="11662948" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3" length="11662948" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-016-jQueryMeetups.mp3</guid>
 			<pubDate>Fri, 19 Mar 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:24:08</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -365,8 +365,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>John Resig joins in to discuss the last two point releases</itunes:subtitle>
 			<itunes:summary>We talk with John Resig about jQuery 1.4.1 and jQuery 1.4.2 as well as what's ahead in jQuery 1.4.3 and beyond.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3" length="21565476" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3" length="21565476" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-015-JohnResig.mp3</guid>
 			<pubDate>Fri, 12 Mar 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:44:46</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -376,8 +376,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Phil Haack, Senior Program Manager for ASP.NET MVC at Microsoft</itunes:subtitle>
 			<itunes:summary>We talk with Phil Haack of Microsoft to talk about how jQuery is now included in Visual Studio and ASP.NET MVC and how easy it is to use.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3" length="28246112" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3" length="28246112" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-014-PhilHaack.mp3</guid>
 			<pubDate>Fri, 5 Mar 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:58:41</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -387,8 +387,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>David Walsh, Mootools developer talks about how Mootools and jQuery compare.</itunes:subtitle>
 			<itunes:summary>We talk with Mootools developer David Walsh and discuss the relationship between our teams and compare the libraries.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3" length="30735680" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3" length="30735680" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-013-DavidWalsh.mp3</guid>
 			<pubDate>Fri, 26 Feb 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>01:03:52</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -398,8 +398,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Rey Bango, Cody Lindley, Karl Swedberg and Doug Neiner Talk jQuery</itunes:subtitle>
 			<itunes:summary>We talk about jQuery at a casual level and try to discuss some topics we normally wouldn't during an interview episode.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3" length="48838960" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3" length="48838960" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-012-ReyBomb1.mp3</guid>
 			<pubDate>Fri, 19 Feb 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:50:48</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -409,8 +409,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>We talk with Yehuda Katz about Rails and jQuery.</itunes:subtitle>
 			<itunes:summary>Our last show while in Washington DC we sat down and talked with Yehuda Katz about Rails 3 and jQuery.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3" length="28399510" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3" length="28399510" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-011-YehudaKatz.mp3</guid>
 			<pubDate>Fri, 12 Feb 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:29:30</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14, rails</itunes:keywords>
@@ -420,8 +420,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>appendTo's Mike Hostetler &amp; Jonathan Sharp talk about the new jQuery company</itunes:subtitle>
 			<itunes:summary>We took the opportunity to sit down with Mike Hostetler and Jonathon Sharp to discuss appendTo.  The first jQuery company that provides support, training and consultation at the Enterprise level.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3" length="36958889" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3" length="36958889" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-010-appendTo.mp3</guid>
 			<pubDate>Fri, 5 Feb 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:38:25</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14</itunes:keywords>
@@ -431,8 +431,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>David Artz, Director of Website Optimization at Aol.</itunes:subtitle>
 			<itunes:summary>We took the opportunity to sit down with David Artz and discuss how jQuery is used at Aol.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3" length="22683494" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3" length="22683494" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-009-DavidArtzAol.mp3.mp3</guid>
 			<pubDate>Fri, 29 Jan 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:23:33</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14</itunes:keywords>
@@ -442,8 +442,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Karl Swedberg and Paul Irish talk about the new api.jquery.com site.</itunes:subtitle>
 			<itunes:summary>The jQuery Documentation got a major facelift and was released during the 14 Days of jQuery.  Find out what's new in the site.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3" length="12632628" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3" length="12632628" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-008-api.jquery.com.mp3</guid>
 			<pubDate>Fri, 22 Jan 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:26:09</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14</itunes:keywords>
@@ -453,8 +453,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>jQuery 1.4 is now released!</itunes:subtitle>
 			<itunes:summary>We are in Washington DC and we are all sitting face-to-face with John Resig as we talk about the jQuery 1.4 Release.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3" length="27839436" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3" length="27839436" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-007-jQuery14.mp3</guid>
 			<pubDate>Fri, 15 Jan 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>00:28:55</itunes:duration>
 			<itunes:keywords>jquery, javascript, jquery14</itunes:keywords>
@@ -464,8 +464,8 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Ben Alman, jQuery Plugin Developer and Core Contributor</itunes:subtitle>
 			<itunes:summary>We talk with Ben Alman about writing plugins and contributing to jQuery.  Elijah joins us after getting braces on, much hilarity ensues.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3" length="38173477" type="audio/mpeg" />
-			<guid>http://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3</guid>
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3" length="38173477" type="audio/mpeg" />
+			<guid>https://content.jquery.com/podcast/jQueryPodcast-006-BenAlman.mp3</guid>
 			<pubDate>Fri, 08 Jan 2010 08:00:00 -0500</pubDate>
 			<itunes:duration>01:19:22</itunes:duration>
 			<itunes:keywords>jquery, javascript</itunes:keywords>
@@ -475,7 +475,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Rey Bango, Head jQuery Evangelist</itunes:subtitle>
 			<itunes:summary>Rey Bango is the Head jQuery Evangelist, he talks with us about evangelism and what to expect in 2010.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3" length="24581443" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3" length="24581443" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-005-ReyBango.mp3</guid>
 			<pubDate>Fri, 18 Dec 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>51:03</itunes:duration>
@@ -486,7 +486,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Cody Lindley, jQuery Enlightenment Author and jQuery Evangelist</itunes:subtitle>
 			<itunes:summary>Cody Lindley is the author of the e-book jQuery Enlightenment and the coauthor of jQuery Cookbook. Learn all about the recently released jQuery books.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3" length="29461536" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3" length="29461536" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-004-CodyLindley.mp3</guid>
 			<pubDate>Fri, 11 Dec 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>01:01:13</itunes:duration>
@@ -497,7 +497,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Paul Irish, yayQuery cohost and front-end developer</itunes:subtitle>
 			<itunes:summary>Paul Irish is a front-end developer and co-host of the other jQuery podcast called yayQuery.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3" length="34539110" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3" length="34539110" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-003-PaulIrish.mp3</guid>
 			<pubDate>Fri, 4 Dec 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>01:11:48</itunes:duration>
@@ -508,7 +508,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>jQuery UI Release Manager, Richard D. Worth</itunes:subtitle>
 			<itunes:summary>Richard D. Worth, Release Manager for the jQuery UI project joins us to explain jQuery UI and how you can contribute.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3" length="43090160" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3" length="43090160" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-002-RichardDWorth.mp3</guid>
 			<pubDate>Fri, 20 Nov 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>01:29:37</itunes:duration>
@@ -519,7 +519,7 @@
 			<itunes:author>Ralph Whitbeck &amp; Elijah Manor</itunes:author>
 			<itunes:subtitle>Our first episode with guest John Resig</itunes:subtitle>
 			<itunes:summary>John Resig joins us on our first podcast to talk jQuery, the Software Freedom Conservancy, the upcoming 1.4 release and why Google Groups is dead.</itunes:summary>
-			<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3" length="36978091" type="audio/mpeg" />
+			<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3" length="36978091" type="audio/mpeg" />
 			<guid>http://static.jquery.com/podcast/jQueryPodcast-001-JohnResig.mp3</guid>
 			<pubDate>Fri, 13 Nov 2009 08:00:00 -0500</pubDate>
 			<itunes:duration>01:16:53</itunes:duration>

--- a/source/feed/jQueryPodcastShowNotes.xml
+++ b/source/feed/jQueryPodcastShowNotes.xml
@@ -31,7 +31,7 @@
 <span id="more-358"></span><br />
 </p>
 ]]></content:encoded>
-	<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" length="27949980" type="audio/mpeg" />
+	<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-046-jQConPanel.mp3" length="27949980" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQCon &#8217;11: SF Bay Area &#8211; jQuery UI Keynote</title>
@@ -44,7 +44,7 @@
 		<description><![CDATA[This week we bring you the jQuery UI Keynote given by Richard Worth at the jQuery Conference 2011: San Francisco Bay Area. Rich presents the state of jQuery UI as well as provide a preview into the new Grid control project. You can subscribe to the show in iTunes or via the raw RSS feed [...]]]></description>
 		<content:encoded><![CDATA[<p>This week we bring you the jQuery UI Keynote given by Richard Worth at the jQuery Conference 2011: San Francisco Bay Area.  Rich presents the state of jQuery UI as well as provide a preview into the new Grid control project. </p>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" length="28509413" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-045-jQueryUIKeynote.mp3" length="28509413" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQuery 1.5 &#8211; 1.6.1</title>
@@ -66,7 +66,7 @@
 <li><a href="https://developer.mozilla.org/en/DOM/window.mozRequestAnimationFrame">window.mozRequestAnimationFrame</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" length="26581160" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-044-jQuery15161.mp3" length="26581160" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>RewardJS</title>
@@ -85,7 +85,7 @@
 <li><a href="http://jQueryUI.com">jQuery UI</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" length="17975180" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-043-RewardJS.mp3" length="17975180" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQCon &#8217;11: SF Bay Area &#8211; jQuery Mobile Keynote</title>
@@ -103,7 +103,7 @@
 <li><a href="http://filamentgroup.com/lab/slides_from_our_jquery_conference_presentation_on_jquery_mobile/">Slides</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" length="33597455" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-042-jQCon11SFjQueryMobileKeynote.mp3" length="33597455" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQCon &#8217;11: SF Bay Area  &#8211; jQuery Keynote</title>
@@ -121,7 +121,7 @@
 <li><a href="http://www.slideshare.net/jeresig/jquery-keynote-spring-2011">Slides from the keynote</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" length="18742768" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-041-jQCon11SFjQueryKeynote.mp3" length="18742768" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>Wijmo</title>
@@ -141,7 +141,7 @@
 <li><a href="http://wijmo.com/wijmo-1-0-has-landed/">Wijmo 1.0 has landed</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" length="16034175" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-040-Wijmo.mp3" length="16034175" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQuery Mobile</title>
@@ -159,7 +159,7 @@
 <li><a href="http://jquerysummit.com">jQuery Summit</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" length="12344425" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-039-jQueryMobile.mp3" length="12344425" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>jQuery 1.4.3</title>
@@ -180,7 +180,7 @@
 <li><a href="http://code.jquery.com/jquery-1.4.4rc1.js">jQuery 1.4.4 RC 1</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" length="14397440" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-038-jQuery143.mp3" length="14397440" type="audio/mpeg" />
 	</item>
 	<item>
 		<title>Ben Nadel</title>
@@ -206,7 +206,7 @@
 <li><a href="http://wijmo.com/">Wijmo jQuery UI Widgets</a></li>
 </ul>
 ]]></content:encoded>
-		<enclosure url="http://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" length="17577483" type="audio/mpeg" />
+		<enclosure url="https://content.jquery.com/podcast/jQueryPodcast-037-BenNadel.mp3" length="17577483" type="audio/mpeg" />
 		</item>
 	</channel>
 </rss>


### PR DESCRIPTION
I noticed this when checking for CSP errors. It may not have been possible in the past, but this site can now load everything from content.jquery.com using https.

Ref https://github.com/jquery/infrastructure-puppet/issues/54